### PR TITLE
use functions to operate file system instead of join

### DIFF
--- a/src/get_sim_params.jl
+++ b/src/get_sim_params.jl
@@ -18,8 +18,8 @@ function get_sim_params(ARGS)
 
     key = "output"
     filename = data[key]["filename"]
-    workdir = join(split(path,"/")[1:end-1],"/")
-    output_path = join([workdir, filename], "/")
+    workdir = dirname(path)
+    output_path = joinpath(workdir, basename(filename))
 
     println()
     println("Loading: ", path)


### PR DESCRIPTION
This PR revises the definition of `workdir` and `output_path ` using functions to operate path of file.

(I confirmed `julia test/runtest.jl` works fine.)